### PR TITLE
Link 'ml' and 'ui' services together.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,28 @@
 # Dockerized Sentiment Analysis application
 
-This repo is for developing a Dockerized sentiment analysis application that I built in [this repo](https://github.com/bhavenp/deployable_sentiment_analysis/).
+This repo is for developing a Dockerized sentiment analysis application that I built in [this repo](https://github.com/bhavenp/deployable_sentiment_analysis/). Most directories have a `README` file to describe what is going on and for me to take notes. Most of the code is commented so I can remember how things are working and learning lessons learned from this project.
 
-## Steps
-1. Build a Docker container that serves the sentiment analysis model. This model should only have to be loaded once when the containers starts up.
-2. Build a Docker container that serves the UI through which users can submit a sentence. The UI will then send a request to the model container and show the related sentiment score.
+## Development Steps
+1. Build a Docker container that serves the sentiment analysis model as the _ml_service_. This model should only have to be loaded once when the container starts up.
+2. Build a Docker container that serves the UI through which users can submit a sentence. This service is called the _ui_service_ The UI will then send a request to the model container and show the related sentiment score.
+3. Use `docker-compose` to bring up both services and link them together.
 
-## Present
-1. You can run the backend part of the application by going into the `ml_app/` direcotry and following the instructions in the `README.md` file.
+## Steps to run Dockerized sentiment analysis application locally
+1. From the root of this repo, run `docker-compose build` to build the images for the _ml_service_ and the _ui_service_. This will take a couple of minutes, especially since `tensorflow` is a large package.
+	1. Run `docker images`. You should see images called `sentiment_analysis_ml_service` (for the _ml_service_) and `sentiment_analysis_ui_service` (for the _ui_service_).
+2. Start up the _ml_service_ in the background by running `docker-compose up -d ml_service`.
+	1. If you run `docker ps`, you should see a container running with the name `ml_service`.
+	2. If you go to [http://localhost:8000/](http://localhost:8000/), you should see the message "ML model service is running!".
+3. Start up the _ui_service_ by running `docker-compose up ui_service`.
+	1. You should the logs for starting up the container for the _ui_service_ in your Terminal window.
+	2. In a new Terminal window if you run `docker ps`, you should see a container running with the name `ui_service`.
+	2. If you go to [http://localhost:8001/](http://localhost:8001/), you should see the web UI displayed.
+4. Visit [http://localhost:8001/](http://localhost:8001/) and type in sentences that you would like to get the sentiment for!
+5. Clean-up:
+	1. Run `docker rm -f ui_service ml_service` to stop and remove the containers.
+	2. Run `docker ps -a` to verify that there are no containers running.
 
-## Issues:
-1. Pre-trainined model for embedding layer is cached locally, so when the cache is emptied automatically, tensorflow still thinks the model is cached locally.
-	1. __Solution:__ I removed the directory where tensorflow_hub caches the model, then I reran the training process. Tested that the app works too.
+### Alternative
+1. Run `docker-compose up` from the root of the repo. This will build images for both services and start them up. The logs for both services will print to your Terminal window.
+2. Go to [http://localhost:8001/](http://localhost:8001/) to use the application.
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,18 +1,20 @@
 version: "3" # Docker compose version I am using
 services:
   ml_service:
-    container_name: ml_service
+    image: sentiment_analysis_ml_service # tag to use when generating an image
+    container_name: ml_service # name for the container when it starts up
     restart: always # Docker will restart container if it exits
     build: ./ml_service # Build from ui_service directory
     ports:
       - "8000:8000"
   ui_service:
+    image: sentiment_analysis_ui_service
     container_name: ui_service
     restart: always
     build: ./ui_service # Build from ui_service directory
-    depends_on:
+    depends_on: # Express dependency order. ui_service needs ml_service to be running.
       - ml_service
     ports:
       - "8001:8001" # Specify the port forwarding
     # Connect to the ml_service by sending request to container name and the open port for that container
-    command: http://ml_service:8000/predict 
+    command: http://ml_service:8000/predict

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3" # Docker compose version I am using
+services:
+  ml_service:
+    container_name: ml_service
+    restart: always # Docker will restart container if it exits
+    build: ./ml_service # Build from ui_service directory
+    ports:
+      - "8000:8000"
+  ui_service:
+    container_name: ui_service
+    restart: always
+    build: ./ui_service # Build from ui_service directory
+    depends_on:
+      - ml_service
+    ports:
+      - "8001:8001" # Specify the port forwarding
+    # Connect to the ml_service by sending request to container name and the open port for that container
+    command: http://ml_service:8000/predict 

--- a/ml_service/Dockerfile
+++ b/ml_service/Dockerfile
@@ -1,7 +1,7 @@
 # Use official Docker image for python 3.6.10
 FROM python:3.6.10-slim-buster
 
-WORKDIR /usr/src/ml_service
+WORKDIR /ml_service
 
 # Copy over requirements.txt and install dependencies
 COPY Docker_related_files/requirements.txt .

--- a/ui_service/Dockerfile
+++ b/ui_service/Dockerfile
@@ -1,7 +1,7 @@
 # Use official Docker image for python 3.6.10
 FROM python:3.6.10-slim-buster
 
-WORKDIR /usr/src/ui_service
+WORKDIR /ui_service
 
 # Copy over requirements.txt and install dependencies
 COPY requirements.txt .

--- a/ui_service/Dockerfile
+++ b/ui_service/Dockerfile
@@ -1,5 +1,3 @@
-ARG ml_service_url
-
 # Use official Docker image for python 3.6.10
 FROM python:3.6.10-slim-buster
 
@@ -25,5 +23,9 @@ RUN pip install -e .
 
 RUN chmod +x run.sh
 
-EXPOSE 8001
-ENTRYPOINT ["./run.sh", "$ml_service_url"]
+# Port to expose for the container
+EXPOSE 8001 
+
+ENTRYPOINT ["./run.sh"]
+# Allow users to specify the ml-service URL
+CMD [""] 

--- a/ui_service/Dockerfile
+++ b/ui_service/Dockerfile
@@ -1,3 +1,5 @@
+ARG ml_service_url
+
 # Use official Docker image for python 3.6.10
 FROM python:3.6.10-slim-buster
 
@@ -24,4 +26,4 @@ RUN pip install -e .
 RUN chmod +x run.sh
 
 EXPOSE 8001
-ENTRYPOINT ["./run.sh"]
+ENTRYPOINT ["./run.sh", "$ml_service_url"]

--- a/ui_service/README.md
+++ b/ui_service/README.md
@@ -1,12 +1,12 @@
-This directory contains the code for the frontend service of the application, which is referred to as the _ui-service_. This service displays a nice UI in a web browser for the user to interact with. Users are able to type out their sentences and get sentiment predictions for their sentences.
+This directory contains the code for the frontend service of the application, which is referred to as the _ui_service_. This service displays a nice UI in a web browser for the user to interact with. Users are able to type out their sentences and get sentiment predictions for their sentences because this service is connected to the _ml_service_.
 
 ## Start-up the UI service WITH DOCKER
 1. Run `docker build <docker_repo_name>/<tag> .` to build the Docker image. The `Dockerfile` contains the instructions for building the Docker image.
 2. Run `docker images` to find the Docker image ID for the image you just built.
 3. Run `docker run -d -p 8001:8001 --name=sentiment-anlysis-frontend <docker_image_ID> <ml-service_URL>`.
-	1. The _ui-service_ will start up in the background on [http://0.0.0.0:8001/](http://0.0.0.0:8001/), so you should see UI when you visit that page.
-	2. The `ml-service_URL` is an _optional_ parameter that can be specified. If not specified, the _ui-service_ will try to connect with the _ml-service_ at 'http://0.0.0:8000/predict'.
-	2. __IMPORTANT:__ If the `ml-service_URL` is a `localhost` address then the _ml-service_ will not be available to the _ui-service_, even if the _ml-service_ is running locally or in a Docker container. You will get an error message that says the UI could not connect to the _ml-service_ because the _localhost_ inside of a Docker container is not the same _localhost_ as your computer. You must use `docker-compose` to bring up both services together and couple them.
+	1. The _ui_service_ will start up in the background on [http://0.0.0.0:8001/](http://0.0.0.0:8001/), so you should see UI when you visit that page.
+	2. The `ml-service_URL` is an _optional_ parameter that can be specified. If not specified, the _ui_service_ will try to connect with the _ml_service_ at 'http://0.0.0:8000/predict'.
+	2. __IMPORTANT:__ If the `ml-service_URL` is a `localhost` address then the _ml_service_ will not be available to the _ui_service_, even if the _ml_service_ is running locally or in a Docker container. You will get an error message that says the UI could not connect to the _ml_service_ because the _localhost_ inside of a Docker container is not the same _localhost_ as your computer. You must use `docker-compose` to bring up both services together and provide a network for them to communicate over.
 4. Stop the container using `docker stop <container_ID>` and remove it using `docker rm <container_ID>`.
 
 ## Start-up the UI service WITHOUT DOCKER
@@ -14,13 +14,13 @@ This directory contains the code for the frontend service of the application, wh
 	1. Run `conda env create -f sentiment_analysis_ui_env.yaml`.
 	2. Run `conda activate sentiment_analysis_ui_env` to start the Conda environment.
 2. Install the project by running `pip install -e .`. This will allow all of the modules for this part of the application to be imported correctly.
-3. Test that this backend application can be run properly using `pytest`.
+3. Test that this frontend application can be run properly using `pytest`.
 	1. Run `pytest -v` from this directory. This will test the application using the tests contained in the `tests/` directory.
 	2. At the bottom of your Terminal screen, you should see `3 passed`, indicating that the app should work correctly.
 4. Start up the application locally:
 	1. From the root directory, execute `chmod +x run.sh`. This shell script will start up a Gunicorn server that runs the Flask application.
-	2. From the root directory, execute `./run.sh`. An optional second argument can be provided to specify the URL for the _ml-service_ by running `./run.sh <ml-service_URL>`.
-		1. If a no arguments are provided, then the _ui-service_ will assume the _ml-service_ is running on `http://0.0.0.0:8000`.
+	2. From the root directory, execute `./run.sh`. An optional second argument can be provided to specify the URL for the _ml_service_ by running `./run.sh <ml-service_URL>`.
+		1. If a no arguments are provided, then the _ui_service_ will assume the _ml_service_ is running on `http://0.0.0.0:8000`.
 	3. The app will start up on [http://0.0.0.0:8001/](http://0.0.0.0:8001/), which is the home page. A user can input a sentence in the provided text box and click _Submit_ to get a sentiment score for the given sentence.
 	4. __IMPORTANT:__ A sentiment score will only be returned if the ML service is running (in a Docker container or just locally). If the ML service is not running, you should see a message that says "Could not connect to 'http://0.0.0:8000/predict'." or the specified URL to the _ml-service_.
 

--- a/ui_service/README.md
+++ b/ui_service/README.md
@@ -1,11 +1,12 @@
-This directory contains the code for the frontend service of the application, which displays a nice UI in a web browser for the user to interact with. Users are able to type out their sentences and get sentiment predictions for their sentences.
+This directory contains the code for the frontend service of the application, which is referred to as the _ui-service_. This service displays a nice UI in a web browser for the user to interact with. Users are able to type out their sentences and get sentiment predictions for their sentences.
 
 ## Start-up the UI service WITH DOCKER
 1. Run `docker build <docker_repo_name>/<tag> .` to build the Docker image. The `Dockerfile` contains the instructions for building the Docker image.
 2. Run `docker images` to find the Docker image ID for the image you just built.
-3. Run `docker run -d -p 8001:8001 --name=sentiment-anlysis-frontend <docker_image_ID>`.
-	1. The frontend service will start up in the background on [http://0.0.0.0:8001/](http://0.0.0.0:8001/), so you should see UI when you visit that page. 
-	2. __IMPORTANT:__ When you start up the UI service this way, you are not coupling it to the ML service, even if the ML service is running. You will get an error message that says the UI could not connect to the ML service because the _localhost_ inside of a Docker container is not the same _localhost_ as your computer. You must use `docker-compose` to bring up both services together and couple them.
+3. Run `docker run -d -p 8001:8001 --name=sentiment-anlysis-frontend <docker_image_ID> <ml-service_URL>`.
+	1. The _ui-service_ will start up in the background on [http://0.0.0.0:8001/](http://0.0.0.0:8001/), so you should see UI when you visit that page.
+	2. The `ml-service_URL` is an _optional_ parameter that can be specified. If not specified, the _ui-service_ will try to connect with the _ml-service_ at 'http://0.0.0:8000/predict'.
+	2. __IMPORTANT:__ If the `ml-service_URL` is a `localhost` address then the _ml-service_ will not be available to the _ui-service_, even if the _ml-service_ is running locally or in a Docker container. You will get an error message that says the UI could not connect to the _ml-service_ because the _localhost_ inside of a Docker container is not the same _localhost_ as your computer. You must use `docker-compose` to bring up both services together and couple them.
 4. Stop the container using `docker stop <container_ID>` and remove it using `docker rm <container_ID>`.
 
 ## Start-up the UI service WITHOUT DOCKER

--- a/ui_service/README.md
+++ b/ui_service/README.md
@@ -18,9 +18,10 @@ This directory contains the code for the frontend service of the application, wh
 	2. At the bottom of your Terminal screen, you should see `3 passed`, indicating that the app should work correctly.
 4. Start up the application locally:
 	1. From the root directory, execute `chmod +x run.sh`. This shell script will start up a Gunicorn server that runs the Flask application.
-	2. From the root directory, execute `./run.sh`.
+	2. From the root directory, execute `./run.sh`. An optional second argument can be provided to specify the URL for the _ml-service_ by running `./run.sh <ml-service_URL>`.
+		1. If a no arguments are provided, then the _ui-service_ will assume the _ml-service_ is running on `http://0.0.0.0:8000`.
 	3. The app will start up on [http://0.0.0.0:8001/](http://0.0.0.0:8001/), which is the home page. A user can input a sentence in the provided text box and click _Submit_ to get a sentiment score for the given sentence.
-	4. __IMPORTANT:__ A sentiment score will only be returned if the ML service is running (in a Docker container or just locally). If the ML service is not running, you should see a message that says "Could not connect to 'http://0.0.0:8000/predict'." 
+	4. __IMPORTANT:__ A sentiment score will only be returned if the ML service is running (in a Docker container or just locally). If the ML service is not running, you should see a message that says "Could not connect to 'http://0.0.0:8000/predict'." or the specified URL to the _ml-service_.
 
 
 ## Folder Descriptions

--- a/ui_service/run.sh
+++ b/ui_service/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-if [ $# -eq 0 ]
+if [ -z "$1" ] # Check if first argument was provided. If not, then the first argument is null.
 then
 	# 'run_app' is the module name, and 'create_app()' is the callable that should be found
 	# in the module. We need quotes around the <module>:<callable> because the callable returns

--- a/ui_service/run.sh
+++ b/ui_service/run.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
-# 'run_app' is the module name, and 'create_app()' is the callable that should be found
-# in the module. We need quotes around the <module>:<callable> because the callable returns
-# the actual application as defined by our application factory pattern.
 
-# '-w 2' runs the Flask application with 2 worker processes.
-exec gunicorn -w 2 --bind 0.0.0.0:8001 "run_app:create_app()"
+if [ $# -eq 0 ]
+then
+	# 'run_app' is the module name, and 'create_app()' is the callable that should be found
+	# in the module. We need quotes around the <module>:<callable> because the callable returns
+	# the actual application as defined by our application factory pattern.
+
+	# '-w 2' runs the Flask application with 2 worker processes.
+
+	exec gunicorn -w 1 --bind 0.0.0.0:8001 "run_app:create_app()"
+
+else # An extra argument was provided, which must be the URL for the ml-service
+	exec gunicorn -w 1 --bind 0.0.0.0:8001 "run_app:create_app(\"$1\")"
+fi

--- a/ui_service/run_app.py
+++ b/ui_service/run_app.py
@@ -11,7 +11,7 @@ from ui_api import ui_bp
 This is the application factory function.
 Any configuration, registration, and other setup the application needs will happen inside the function, then the application will be returned.
 '''
-def create_app():
+def create_app(ml_service_url="http://0.0.0.0:8000/predict"):
 
 	dir_path = Path(os.path.dirname(os.path.realpath(__file__))) # get the path to the directory in which run_app.py resides
 	logs_path = dir_path / "logs/logging.yaml"
@@ -24,6 +24,7 @@ def create_app():
 	def hello():
 		return "Hello World!"
 
+	app.ml_service_url = ml_service_url # Bind the URL to connect to the ml-service for predictions
 	app.register_blueprint(ui_bp)
 
 	return app

--- a/ui_service/ui_api/ui_blueprint.py
+++ b/ui_service/ui_api/ui_blueprint.py
@@ -11,15 +11,21 @@ ui_bp = Blueprint('ui_bp', __name__) # create a Blueprint object
 
 def send_prediction_request(sentence):
     try:
-        response = requests.post('http://0.0.0.0:8000/predict', 
+        response = requests.post(current_app.ml_service_url, 
             json={"sentences": [sentence]})
     except requests.exceptions.ConnectionError: # Catch error when ML service is not running
-        return "Could not connect to \'http://0.0.0:8000/predict\'. Check if the ML service is running."
+        msg = f"Could not connect to \'{current_app.ml_service_url}\'. Check if the ML service is running."
+        current_app.logger.error(msg)
+        return msg
     except Exception as e: # Catch all other errors
-        return str(e)
+        msg = str(e)
+        current_app.logger.error(msg)
+        return msg
 
     if response.status_code != 200:
-        return "Error in sending request to ML model endpoint"
+        msg = f"Error in sending request to ML model endpoint at \'{current_app.ml_service_url}\'"
+        current_app.logger.error(msg)
+        return msg
     
     json_data = response.json()
     return str(json_data['pred'][0][0]) # pred is a list with another list inside of it


### PR DESCRIPTION
1. Changed ui-service so that the endpoint for the ml-service can be specified when the service starts up.
2. Updated docs about how to run ui-service locally and with Docker.
3. Use `docker-compose` to build images for services and run them.